### PR TITLE
Enhancements

### DIFF
--- a/treesit-jump.el
+++ b/treesit-jump.el
@@ -24,16 +24,16 @@
 ;; https://github.com/emacs-mirror/emacs/blob/master/admin/notes/tree-sitter/starter-guide
 ;; https://git.sr.ht/~meow_king/ts-query-highlight
 
+(require 'transient)
 (require 'treesit)
 (require 'cl-lib)
 (require 'avy nil 'noerror)
 (require 'gptel)
 (require 'map)
 
-;;;###autoload
-(eval-and-compile (require 'transient)) ;; use eval-and-compile to fix byte-compile issues with transient macro
 
-;;;###autoload
+
+;;;###autoload(autoload 'treesit-jump-transient "treesit-jump" "Transient for using treesit-jump." t)
 (transient-define-prefix treesit-jump-transient ()
   "Transient for using treesit-jump."
   ["Treesit-Jump"

--- a/treesit-jump.el
+++ b/treesit-jump.el
@@ -5,7 +5,7 @@
 ;; Author: Donovan Miller
 ;; URL: https://github.com/dmille56/treesit-jump
 ;; Package-Version: 0.0.1
-;; Package-Requires: ((emacs "29.1") (avy "0.4") (transient "0.5.3") (gptel "0.8.5"))
+;; Package-Requires: ((emacs "29.1") (avy "0.4") (transient "0.5.3"))
 ;; Keywords: treesit, treesitter, avy, jump, matching, gptel
 
 ;;; Commentary:
@@ -28,9 +28,9 @@
 (require 'treesit)
 (require 'cl-lib)
 (require 'avy nil 'noerror)
-(require 'gptel)
 (require 'map)
 
+(declare-function gptel-request "gptel")
 
 
 ;;;###autoload(autoload 'treesit-jump-transient "treesit-jump" "Transient for using treesit-jump." t)
@@ -360,6 +360,8 @@ Outputs the RESPONSE to a new buffer.  INFO unused for now."
 (defun treesit-jump-gptel-describe ()
   "Select and select the region of a treesit query for the current major-mode."
   (interactive)
+  (unless (require 'gptel nil :noerror)
+    (user-error "You need to install `gptel' to use this command"))
   (treesit-jump-get-and-process-captures #'treesit-jump--query-select-visual)
   (if (use-region-p)
       (progn

--- a/treesit-jump.el
+++ b/treesit-jump.el
@@ -201,7 +201,6 @@
 
 (defun treesit-jump--query-select-go-to (query-list)
   "Input a `QUERY-LIST' select a capture from it and go to it."
-  (interactive)
   (let* (
          (selected (treesit-jump--query-select query-list))
          (start (treesit-node-start (cdr selected))))
@@ -210,7 +209,6 @@
 
 (defun treesit-jump--query-select-visual (query-list)
   "Input a `QUERY-LIST' select a capture from it and select it's region."
-  (interactive)
   (let* (
          (selected (treesit-jump--query-select query-list))
          (start (treesit-node-start (cdr selected)))
@@ -221,7 +219,6 @@
 
 (defun treesit-jump--query-select-delete (query-list)
   "Input a `QUERY-LIST' select a capture from it and delete it."
-  (interactive)
   (let* (
          (selected (treesit-jump--query-select query-list))
          (start (treesit-node-start (cdr selected)))

--- a/treesit-jump.el
+++ b/treesit-jump.el
@@ -56,7 +56,7 @@
 (defcustom treesit-jump-queries-filter-mode-alist nil
   "Query captures to filter out of results using regex for each mode."
   :group 'treesit-jump
-  :type '(alist :key-type (symbol) :value-type '(repeat string)))
+  :type '(alist :key-type (symbol) :value-type (repeat string)))
 
 (defcustom treesit-jump-queries-filter-func #'treesit-jump--queries-filter-default-func
   "Function used to filter matched treesit queries."
@@ -71,7 +71,7 @@
 (defcustom treesit-jump-queries-extra-alist nil
   "Alist that maps major modes to extra queries to search for."
   :group 'treesit-jump
-  :type '(alist :key-type (symbol) :value-type '(repeat string)))
+  :type '(alist :key-type (symbol) :value-type (repeat string)))
 
 (defcustom treesit-jump-code-describe-prompt "You are an expert programmer.  Describe this code."
   "Prompt string to use when describing code using treesit-jump."
@@ -304,10 +304,10 @@ It might not be on the fist line and so we cannot just get the first line."
 
     (unless (treesit-language-available-p (intern lang-name))
       (error (format "Treesit is not available for language %s" lang-name)))
-    
+
     (unless (file-directory-p treesit-jump-queries-dir)
       (error (format "Treesit-queries directory not found at: %s. Make sure your config include the treesit-queries directory if using straight." treesit-jump-queries-dir)))
-    
+
     (let* (
            (queries-dir treesit-jump-queries-dir)
            (query (treesit-jump--get-query-from-cache-or-dir lang-name queries-dir t))
@@ -334,7 +334,7 @@ It might not be on the fist line and so we cannot just get the first line."
   (treesit-jump-get-and-process-captures #'treesit-jump--query-select-delete))
 
 (defun treesit-jump--gptel-callback (response info)
-  "Callback function from calling gptel-request.
+  "Callback function from calling `gptel-request'.
 Outputs the RESPONSE to a new buffer.  INFO unused for now."
   (if response
       (let ((buffer (treesit-jump--get-or-create-buffer treesit-jump--gpt-buffer-name)))


### PR DESCRIPTION
Hello and thank you for the package!

This PR introduce some improvements:

1. The current implementation forces Transient to be loaded at startup (when reading the generated autoloads file). This is not a sane default, since this can increase Emacs' startup time, and the user can prefer to load the `transient` package only when needed.
2. The functions `treesit-jump--query-select-*` are marked as interactive (visible in `M-x`), however, they don't have any actual benefit for the user.
3. `treesit-jump` can work without `gptel`, it doesn't **depend** on it, but it can extend it when using the `treesit-jump-gptel-describe`. This makes the `gptel` optional, if the user doesn't have it (or don't want to), the package should still work. 